### PR TITLE
Correcting a bug in parse when day of week of 7 is used in a range

### DIFF
--- a/croncal.pl
+++ b/croncal.pl
@@ -446,7 +446,11 @@ sub parse {
       }
 
       for (my $i = $from; $i <= $to; $i += $step) {
-        push @values, $i;
+        if ($type eq 'dow' && $i eq '7') {
+          push @values, '0';
+        } else {
+          push @values, $i;
+        }
       }
 
     } else {


### PR DESCRIPTION
Example crontab input: 15 21 * * 2-7 command