### PR TITLE
ical now requires VERSION:2.0

### DIFF
--- a/croncal.pl
+++ b/croncal.pl
@@ -233,7 +233,7 @@ for (my $second = $startsec; $second < $endsec; $second += 60) {
 
 if ($outformat eq 'ical') {
   print "BEGIN:VCALENDAR\n";
-  print "VERSION:1.0\n";
+  print "VERSION:2.0\n";
 }
 
 for my $year (sort { $a <=> $b} keys %calendar) {


### PR DESCRIPTION
The rest of the generated ICS data looks good, but Calendar.app requires "VERSION:2.0"